### PR TITLE
Dump to json whenever receive any class

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require ./spec/spec_helper.rb

--- a/lib/qmail_log/format/json.rb
+++ b/lib/qmail_log/format/json.rb
@@ -3,7 +3,7 @@ module QmailLog
     class JSON
       class << self
         def parse data
-          data.to_json
+          ::JSON.dump(data)
         end
       end
     end

--- a/spec/format/json_spec.rb
+++ b/spec/format/json_spec.rb
@@ -1,0 +1,11 @@
+describe QmailLog::Format::JSON do
+  describe '.parse' do
+    it "shouldn't raise any errors when receive String" do
+      expect { QmailLog::Format::JSON.parse('string') }.not_to raise_error
+    end
+
+    it "shouldn't raise any errors when receive nil" do
+      expect { QmailLog::Format::JSON.parse(nil) }.not_to raise_error
+    end
+  end
+end

--- a/spec/qmail_log_spec.rb
+++ b/spec/qmail_log_spec.rb
@@ -1,11 +1,5 @@
-require 'spec_helper'
-
 describe QmailLog do
   it 'has a version number' do
     expect(QmailLog::VERSION).not_to be nil
-  end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
   end
 end


### PR DESCRIPTION
If QmailLog::Format::JSON.perse receive args expect Array or Hash,
it raise NoMethodError because args don't have to_json.

Therefore we should use JSON.dump.
