### PR TITLE
QmailLog::Analyze::Helper.delivery should keep delivery status's spaces

### DIFF
--- a/lib/qmail_log/analyze/helper.rb
+++ b/lib/qmail_log/analyze/helper.rb
@@ -34,7 +34,7 @@ module QmailLog
         _, delivery_id, *status = content.split
         {
           delivery_id: delivery_id.gsub(':', ''),
-          status:      status.join
+          status:      status.join(' ')
         }
       end
     end

--- a/spec/analyze/helper_spec.rb
+++ b/spec/analyze/helper_spec.rb
@@ -1,0 +1,73 @@
+describe QmailLog::Analyze::Helper do
+  let(:including_class) { Class.new { include QmailLog::Analyze::Helper }.new }
+  let(:queue_id)        { '93869' }
+  let(:delivery_id)     { '2392' }
+  let(:qid_from_did)    { { delivery_id => queue_id } }
+  let(:keys)            { %w(new info starting delivery end) }
+
+  describe '.queue_id' do
+    let(:keys)            { %w(new info starting delivery end) }
+
+    it 'should return correct queue_id' do
+      keys.each do |key|
+        content = send("#{key}_log").partition(' ')[-1]
+        expect( including_class.queue_id(content, qid_from_did) ).to eq(queue_id)
+      end
+    end
+  end
+
+  describe '.info' do
+    let(:content) { info_log.partition(' ')[-1] }
+    let(:bytes)   { '2343' }
+    let(:from)    { 'dave@sill.org' }
+    let(:qp)      { '18695' }
+    let(:uid)     { '49491' }
+
+    it 'should return correct bytes' do
+      expect( including_class.info(content)[:bytes] ).to eq(bytes)
+    end
+
+    it 'should return correct from' do
+      expect( including_class.info(content)[:from] ).to eq(from)
+    end
+
+    it 'should return correct qp' do
+      expect( including_class.info(content)[:qp] ).to eq(qp)
+    end
+
+    it 'should return correct qp' do
+      expect( including_class.info(content)[:uid] ).to eq(uid)
+    end
+  end
+
+  describe '.starting' do
+    let(:content) { starting_log.partition(' ')[-1] }
+    let(:region)  { 'remote' }
+    let(:to)      { 'lwq@w3.to' }
+
+    it 'should return correct delivery_id' do
+      expect( including_class.starting(content)[:delivery_id] ).to eq(delivery_id)
+    end
+
+    it 'should return correct region' do
+      expect( including_class.starting(content)[:region] ).to eq(region)
+    end
+
+    it 'should return correct to' do
+      expect( including_class.starting(content)[:to] ).to eq(to)
+    end
+  end
+
+  describe '.delivery' do
+    let(:content) { delivery_log.partition(' ')[-1] }
+    let(:status)  { 'success: 209.85.127.177_accepted_message. /Remote_host_said:_250_CAA01516_Message_accepted_for_delivery/' }
+
+    it 'should return correct delivery_id' do
+      expect( including_class.delivery(content)[:delivery_id] ).to eq(delivery_id)
+    end
+
+    it 'should return correct status' do
+      expect( including_class.delivery(content)[:status] ).to eq(status)
+    end
+  end
+end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,0 +1,75 @@
+module Helpers
+  def log
+    <<-'EOS'
+@4000000038c3eeb027f41c7c new msg 93869
+@4000000038c3eeb027f6b0a4 info msg 93869: bytes 2343 from <dave@sill.org> qp 18695 uid 49491
+@4000000038c3eeb02877ee94 starting delivery 2392: msg 93869 to remote lwq@w3.to
+@4000000038c3eeb0287b55ac status: local 0/10 remote 1/20
+@4000000038c3eeb104a13804 delivery 2392: success: 209.85.127.177_accepted_message. /Remote_host_said:_250_CAA01516_Message_accepted_for_delivery/
+@4000000038c3eeb104a4492c status: local 0/10 remote 0/20
+@4000000038c3eeb104a6ecf4 end msg 93869
+@4000000048c3eeb027f41c7c new msg 869
+@4000000048c3eeb027f6b0a4 info msg 869: bytes 2343 from <dave@sill.org> qp 18695 uid 49491
+@4000000048c3eeb02877ee94 starting delivery 2392: msg 869 to remote lwq@w3.to
+@4000000048c3eeb0287b55ac status: local 0/10 remote 1/20
+@4000000048c3eeb104a13804 delivery 2392: success: 209.85.127.177_accepted_message. /Remote_host_said:_250_CAA01516_Message_accepted_for_delivery/
+@4000000048c3eeb104a4492c status: local 0/10 remote 0/20
+@4000000048c3eeb104a6ecf4 end msg 869
+    EOS
+  end
+
+  def analyzed_log
+    [{:time=>
+      {:new=>"2000-03-06T17:45:10Z",
+       :info=>"2000-03-06T17:45:10Z",
+       :starting=>"2000-03-06T17:45:10Z",
+       :delivery=>"2000-03-06T17:45:11Z",
+       :end=>"2000-03-06T17:45:11Z"},
+       :bytes=>"2343",
+       :from=>"dave@sill.org",
+       :qp=>"18695",
+       :uid=>"49491",
+       :delivery_id=>"2392",
+       :region=>"remote",
+       :to=>"lwq@w3.to",
+       :status=>
+      "success:209.85.127.177_accepted_message./Remote_host_said:_250_CAA01516_Message_accepted_for_delivery/",
+        :queue_id=>"93869"},
+        {:time=>
+         {:new=>"2008-09-07T15:09:26Z",
+          :info=>"2008-09-07T15:09:26Z",
+          :starting=>"2008-09-07T15:09:26Z",
+          :delivery=>"2008-09-07T15:09:27Z",
+          :end=>"2008-09-07T15:09:27Z"},
+          :bytes=>"2343",
+          :from=>"dave@sill.org",
+          :qp=>"18695",
+          :uid=>"49491",
+          :delivery_id=>"2392",
+          :region=>"remote",
+          :to=>"lwq@w3.to",
+          :status=>
+         "success:209.85.127.177_accepted_message./Remote_host_said:_250_CAA01516_Message_accepted_for_delivery/",
+           :queue_id=>"869"}]
+  end
+
+  def new_log
+    '@4000000038c3eeb027f41c7c new msg 93869'
+  end
+
+  def info_log
+    '@4000000038c3eeb027f6b0a4 info msg 93869: bytes 2343 from <dave@sill.org> qp 18695 uid 49491'
+  end
+
+  def starting_log
+    '@4000000038c3eeb02877ee94 starting delivery 2392: msg 93869 to remote lwq@w3.to'
+  end
+
+  def delivery_log
+    '@4000000038c3eeb104a13804 delivery 2392: success: 209.85.127.177_accepted_message. /Remote_host_said:_250_CAA01516_Message_accepted_for_delivery/'
+  end
+
+  def end_log
+    '@4000000038c3eeb104a6ecf4 end msg 93869'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,10 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
 require 'qmail_log'
+require 'helpers'
+
+set :backend, :exec
+
+RSpec.configure do |c|
+  c.include Helpers
+end


### PR DESCRIPTION
Please don't delete spaces :cry: 

This PR add some spec for QmailLog::Analyze::Helper
