### PR TITLE
Qmaillog.analyze should return unfinished log

### DIFF
--- a/lib/qmail_log/analyze.rb
+++ b/lib/qmail_log/analyze.rb
@@ -11,7 +11,8 @@ module QmailLog
       when :exec then klassname = 'Exec'
       when :ssh  then klassname = 'SSH'
       end
-      const_get(klassname).new.tap{ |o| o.run(*args) }.results
+      klass = const_get(klassname).new.tap{ |o| o.run(*args) }
+      { results: klass.results, unfinished: klass.memory }
     end
   end
 end

--- a/lib/qmail_log/analyze/analyzer.rb
+++ b/lib/qmail_log/analyze/analyzer.rb
@@ -26,6 +26,7 @@ module QmailLog
           when /end/
             memory[queue_id][:time][:end] = time
             data << memory[queue_id].merge!({ queue_id: queue_id })
+            memory.delete(queue_id)
           end
 
           memory[queue_id][:time][$1.to_sym] = time if $1

--- a/lib/qmail_log/analyze/base.rb
+++ b/lib/qmail_log/analyze/base.rb
@@ -1,7 +1,7 @@
 module QmailLog
   module Analyze
     class Base
-      attr_reader :results
+      attr_reader :results, :memory
 
       def initialize
         @results      = []

--- a/spec/analyze/exec_spec.rb
+++ b/spec/analyze/exec_spec.rb
@@ -2,6 +2,6 @@ describe QmailLog::Analyze::Exec do
   let(:log) { File.open('./spec/helper/files/log/one.log', &:read) }
 
   it 'should analyze given strings' do
-    expect( QmailLog.analyze(:exec, log) ).to eq(analyzed_log)
+    expect( QmailLog.analyze(:exec, log)[:results] ).to eq(analyzed_log)
   end
 end

--- a/spec/analyze/ssh_spec.rb
+++ b/spec/analyze/ssh_spec.rb
@@ -18,7 +18,7 @@ describe QmailLog::Analyze::SSH do
     let(:path) { './spec/helper/files/log/one.log' }
 
     it 'should analyze given file' do
-      expect( QmailLog.analyze(:ssh, path, host, ssh_options).length ).to eq(2)
+      expect( QmailLog.analyze(:ssh, path, host, ssh_options)[:results].length ).to eq(2)
     end
   end
 
@@ -26,7 +26,7 @@ describe QmailLog::Analyze::SSH do
     let(:path) { './spec/helper/files/log' }
 
     it 'should analyze all files in given directory' do
-      expect( QmailLog.analyze(:ssh, path, host, ssh_options).length ).to eq(4)
+      expect( QmailLog.analyze(:ssh, path, host, ssh_options)[:results].length ).to eq(4)
     end
   end
 end

--- a/spec/analyze_spec.rb
+++ b/spec/analyze_spec.rb
@@ -1,0 +1,10 @@
+describe QmailLog::Analyze do
+  let(:log) { File.open('./spec/helper/files/log/one.log', &:read) }
+  let(:unfinished) do
+    {"12345"=>{:time=>{:new=>"2000-03-06T17:45:10Z", :info=>"2000-03-06T17:45:10Z"}, :bytes=>"2343", :from=>"dave@sill.org", :qp=>"18695", :uid=>"49491"}}
+  end
+
+  it 'should return unfinished log' do
+    expect( QmailLog.analyze(:exec, log)[:unfinished] ).to eq(unfinished)
+  end
+end


### PR DESCRIPTION
resolved https://github.com/alotofwe/qmail_log/issues/7

```
QmailLog.analyze(PATH_TO_LOG) => { results: Array, unfinished: Hash }
```

`results` has current QmailLog.analyze's return value.

`unfinished` has new structure:

```
{
    queue_id: {
        time: {
            new: Time,
            info: Time,
            ...
        },
        bytes: String
    }
    ...
}
```

This hash have unfinished logs.
`unfinished` means that given logs couldn't have all of information about new, info, starting, delivery and end.
